### PR TITLE
Fix CDN bypass for original media

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -78,6 +78,10 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 S3_ALIAS_HOST=files.example.com
 
+# When CDN_HOST is set, set this to true to serve original media files from the
+# origin server instead of the CDN
+# DISABLE_CDN_FOR_MEDIA=true
+
 # Optional list of hosts that are allowed to serve media for your instance
 # EXTRA_MEDIA_HOSTS=https://data.example1.com,https://data.example2.com
 

--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -22,7 +22,7 @@ class MediaProxyController < ApplicationController
       redownload! if @media_attachment.needs_redownload? && !reject_media?
     end
 
-    redirect_to full_asset_url(@media_attachment.file.url(version)), allow_other_host: true
+    redirect_to full_media_url(@media_attachment.file.url(version)), allow_other_host: true
   end
 
   private

--- a/app/helpers/media_component_helper.rb
+++ b/app/helpers/media_component_helper.rb
@@ -8,7 +8,7 @@ module MediaComponentHelper
 
     component_params = {
       sensitive: sensitive_viewer?(status, current_account),
-      src: full_asset_url(video.file.url(:original)),
+      src: full_media_url(video.file.url(:original)),
       preview: full_asset_url(video.thumbnail.present? ? video.thumbnail.url : video.file.url(:small)),
       alt: video.description,
       blurhash: video.blurhash,
@@ -31,7 +31,7 @@ module MediaComponentHelper
     meta = audio.file.meta || {}
 
     component_params = {
-      src: full_asset_url(audio.file.url(:original)),
+      src: full_media_url(audio.file.url(:original)),
       poster: full_asset_url(audio.thumbnail.present? ? audio.thumbnail.url : status.account.avatar_static_url),
       alt: audio.description,
       backgroundColor: meta.dig('colors', 'background'),

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -20,8 +20,18 @@ module RoutingHelper
     URI.join(asset_host, source).to_s
   end
 
+  def full_media_url(source, **)
+    source = ActionController::Base.helpers.asset_url(source, **) unless use_storage?
+
+    URI.join(media_asset_host, source).to_s
+  end
+
   def asset_host
     Rails.configuration.action_controller.asset_host || root_url
+  end
+
+  def media_asset_host
+    ENV['DISABLE_CDN_FOR_MEDIA'] == 'true' ? root_url : asset_host
   end
 
   def frontend_asset_path(source, **)

--- a/app/lib/admin/system_check/media_privacy_check.rb
+++ b/app/lib/admin/system_check/media_privacy_check.rb
@@ -27,7 +27,7 @@ class Admin::SystemCheck::MediaPrivacyCheck < Admin::SystemCheck::BaseCheck
   end
 
   def check_media_listing_inaccessible!
-    full_url = full_asset_url(media_attachment.file.url(:original, false))
+    full_url = full_media_url(media_attachment.file.url(:original, false))
 
     # Check if we can list the uploaded file. If true, that's an error
     directory_url = Addressable::URI.parse(full_url)

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -219,7 +219,7 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
     end
 
     def url
-      object.local? ? full_asset_url(object.file.url(:original, false)) : object.remote_url
+      object.local? ? full_media_url(object.file.url(:original, false)) : object.remote_url
     end
 
     def focal_point?

--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -19,7 +19,7 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
     elsif object.needs_redownload?
       media_proxy_url(object.id, :original)
     else
-      full_asset_url(object.file.url(:original))
+      full_media_url(object.file.url(:original))
     end
   end
 

--- a/app/views/accounts/show.rss.ruby
+++ b/app/views/accounts/show.rss.ruby
@@ -17,11 +17,11 @@ RSS::Builder.build do |doc|
 
       if status.ordered_media_attachments.first&.audio?
         media = status.ordered_media_attachments.first
-        item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, media.file.size)
+        item.enclosure(full_media_url(media.file.url(:original, false)), media.file.content_type, media.file.size)
       end
 
       status.ordered_media_attachments.each do |media_attachment|
-        item.media_content(full_asset_url(media_attachment.file.url(:original, false)), media_attachment.file.content_type, media_attachment.file.size) do |media_content|
+        item.media_content(full_media_url(media_attachment.file.url(:original, false)), media_attachment.file.content_type, media_attachment.file.size) do |media_content|
           media_content.medium(media_attachment.gifv? ? 'image' : media_attachment.type.to_s)
           media_content.rating(status.sensitive? ? 'adult' : 'nonadult')
           media_content.description(media_attachment.description) if media_attachment.description.present?

--- a/app/views/notification_mailer/_status.html.haml
+++ b/app/views/notification_mailer/_status.html.haml
@@ -23,7 +23,7 @@
           %p.email-status-media
             - status.ordered_media_attachments.each do |a|
               - if status.local?
-                = link_to full_asset_url(a.file.url(:original)), full_asset_url(a.file.url(:original))
+                = link_to full_media_url(a.file.url(:original)), full_media_url(a.file.url(:original))
               - else
                 = link_to a.remote_url, a.remote_url
 

--- a/app/views/statuses/_og_image.html.haml
+++ b/app/views/statuses/_og_image.html.haml
@@ -2,7 +2,7 @@
   - player_card = false
   - activity.ordered_media_attachments.each do |media|
     - if media.image?
-      = opengraph 'og:image', full_asset_url(media.file.url(:original))
+      = opengraph 'og:image', full_media_url(media.file.url(:original))
       = opengraph 'og:image:type', media.file_content_type
       - unless media.file.meta.nil?
         = opengraph 'og:image:width', media.file.meta.dig('original', 'width')
@@ -16,11 +16,11 @@
       - unless media.file.meta.nil?
         = opengraph 'og:image:width', media.file.meta.dig('small', 'width')
         = opengraph 'og:image:height', media.file.meta.dig('small', 'height')
-      = opengraph 'og:video', full_asset_url(media.file.url(:original))
-      = opengraph 'og:video:secure_url', full_asset_url(media.file.url(:original))
+      = opengraph 'og:video', full_media_url(media.file.url(:original))
+      = opengraph 'og:video:secure_url', full_media_url(media.file.url(:original))
       = opengraph 'og:video:type', media.file_content_type
       = opengraph 'twitter:player', medium_player_url(media)
-      = opengraph 'twitter:player:stream', full_asset_url(media.file.url(:original))
+      = opengraph 'twitter:player:stream', full_media_url(media.file.url(:original))
       = opengraph 'twitter:player:stream:content_type', media.file_content_type
       - unless media.file.meta.nil?
         = opengraph 'og:video:width', media.file.meta.dig('original', 'width')
@@ -32,11 +32,11 @@
       = opengraph 'og:image', full_asset_url(account.avatar.url(:original))
       = opengraph 'og:image:width', '400'
       = opengraph 'og:image:height', '400'
-      = opengraph 'og:audio', full_asset_url(media.file.url(:original))
-      = opengraph 'og:audio:secure_url', full_asset_url(media.file.url(:original))
+      = opengraph 'og:audio', full_media_url(media.file.url(:original))
+      = opengraph 'og:audio:secure_url', full_media_url(media.file.url(:original))
       = opengraph 'og:audio:type', media.file_content_type
       = opengraph 'twitter:player', medium_player_url(media)
-      = opengraph 'twitter:player:stream', full_asset_url(media.file.url(:original))
+      = opengraph 'twitter:player:stream', full_media_url(media.file.url(:original))
       = opengraph 'twitter:player:stream:content_type', media.file_content_type
       = opengraph 'twitter:player:width', '670'
       = opengraph 'twitter:player:height', '380'

--- a/app/views/tags/show.rss.ruby
+++ b/app/views/tags/show.rss.ruby
@@ -15,11 +15,11 @@ RSS::Builder.build do |doc|
 
       if status.ordered_media_attachments.first&.audio?
         media = status.ordered_media_attachments.first
-        item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, media.file.size)
+        item.enclosure(full_media_url(media.file.url(:original, false)), media.file.content_type, media.file.size)
       end
 
       status.ordered_media_attachments.each do |media_attachment|
-        item.media_content(full_asset_url(media_attachment.file.url(:original, false)), media_attachment.file.content_type, media_attachment.file.size) do |media_content|
+        item.media_content(full_media_url(media_attachment.file.url(:original, false)), media_attachment.file.content_type, media_attachment.file.size) do |media_content|
           media_content.medium(media_attachment.gifv? ? 'image' : media_attachment.type.to_s)
           media_content.rating(status.sensitive? ? 'adult' : 'nonadult')
           media_content.description(media_attachment.description) if media_attachment.description.present?


### PR DESCRIPTION
## Summary
- add new helper `full_media_url` that respects `DISABLE_CDN_FOR_MEDIA`
- use `full_media_url` for original media URLs
- document `DISABLE_CDN_FOR_MEDIA` in `.env.production.sample`

## Testing
- `bundle exec rake spec --dry-run` *(fails: `webpush.git is not yet checked out`)*

------
https://chatgpt.com/codex/tasks/task_e_68491f895e2c8327a5f0bc4cbe00fcda