### PR TITLE
Fix CDN bypass for original media

### DIFF
--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -23,15 +23,23 @@ module RoutingHelper
   def full_media_url(source, **)
     source = ActionController::Base.helpers.asset_url(source, **) unless use_storage?
 
-    URI.join(media_asset_host, source).to_s
+    URI.join(media_asset_host(source), source).to_s
   end
 
   def asset_host
     Rails.configuration.action_controller.asset_host || root_url
   end
 
-  def media_asset_host
-    ENV['DISABLE_CDN_FOR_MEDIA'] == 'true' ? root_url : asset_host
+  def media_asset_host(source = nil)
+    if ENV['DISABLE_CDN_FOR_MEDIA'] == 'true' && bypass_cdn_for?(source)
+      root_url
+    else
+      asset_host
+    end
+  end
+
+  def bypass_cdn_for?(source)
+    source.present? && !source.start_with?('http', 'https') && source.include?('/original/')
   end
 
   def frontend_asset_path(source, **)


### PR DESCRIPTION
## Summary
- tweak `media_asset_host` to accept source and detect original style
- direct `full_media_url` to use the adjusted host logic

## Testing
- `bundle exec rake spec` *(fails: could not find webpush gem)*
- `bundle exec rubocop` *(fails: could not find idn-ruby gem)*


------
https://chatgpt.com/codex/tasks/task_e_6849e3319f9c8327a20126ce5d0a2e27