### PR TITLE
Adjust CDN behavior for original media

### DIFF
--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -17,7 +17,9 @@ module RoutingHelper
   def full_asset_url(source, **)
     source = ActionController::Base.helpers.asset_url(source, **) unless use_storage?
 
-    URI.join(asset_host, source).to_s
+    host = source.to_s.include?('/original/') ? root_url : asset_host
+
+    URI.join(host, source).to_s
   end
 
   def expiring_asset_url(attachment, expires_in)


### PR DESCRIPTION
## Summary
- override `full_asset_url` so URLs containing `/original/` bypass `CDN_HOST`

## Testing
- `bundle exec rspec spec/helpers/routing_helper_spec.rb --format doc --out test.log` *(fails: bundler could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b3255bec08327a5c488c967977900