### PR TITLE
Fix for missing ActivityPub object identifiers

### DIFF
--- a/app/helpers/json_ld_helper.rb
+++ b/app/helpers/json_ld_helper.rb
@@ -63,7 +63,9 @@ module JsonLdHelper
   end
 
   def value_or_id(value)
-    value.is_a?(String) || value.nil? ? value : value['id']
+    return value if value.is_a?(String) || value.nil?
+
+    value['id'] || value['url']
   end
 
   def supported_context?(json)


### PR DESCRIPTION
## Summary
- improve `value_or_id` helper to fall back to `url` when `id` is missing

## Testing
- `RAILS_ENV=test bundle exec rake spec` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*

------
https://chatgpt.com/codex/tasks/task_e_686ac83f68288327be7a7e01cb9c382d