### PR TITLE
Fix paste issue in autosuggest textarea

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -149,7 +149,7 @@ const AutosuggestTextarea = forwardRef(({
   }, [suggestions, onSuggestionSelected, textareaRef]);
 
   const handlePaste = useCallback((e) => {
-    if (e.clipboardData && e.clipboardData.files.length === 1) {
+    if (e.clipboardData && e.clipboardData.files.length === 1 && !e.clipboardData.getData('text/plain')) {
       onPaste(e.clipboardData.files);
       e.preventDefault();
     }


### PR DESCRIPTION
## Summary
- avoid treating formatted text paste as file paste

## Testing
- `yarn test:js run`

------
https://chatgpt.com/codex/tasks/task_e_687199c61650832784cd22493b54203a